### PR TITLE
Remove superfluous dir check.

### DIFF
--- a/bin/gst
+++ b/bin/gst
@@ -11,7 +11,6 @@ SYNOPSIS
 USAGE
     Since gst is a script and runs in a child environment of your shell, the latter will not take the env changes unless you source them.
 
-      $ gst init
       $ source gst in
       $ source gst out
 
@@ -22,7 +21,6 @@ USAGE
       $ gst in gem env home
 
 COMMANDS
-    init    Creates the .gs directory
     in      Modifies GEM_HOME, GEM_PATH and PATH to use the .gs directory and sets the GS_NAME variable.
     out     Restores the previous GEM_HOME, GEM_PATH and PATH. Also unsets GS_NAME.
 EOF
@@ -34,30 +32,24 @@ if [[ "$1" != "in" && "$#" -ne 1 ]]; then
 fi
 
 case "$1" in
-  "init")
-    mkdir .gs;;
   "in")
     GS_DIR="$(pwd)/.gs"
-    if [[ -d $GS_DIR ]]; then
-      if [[ -z $GS_NAME ]]; then
-        GST_OLD_PATH=$PATH
-        GST_OLD_GEM_PATH=$GEM_PATH
-        GST_OLD_GEM_HOME=$GEM_HOME
+    if [[ -z $GS_NAME ]]; then
+      GST_OLD_PATH=$PATH
+      GST_OLD_GEM_PATH=$GEM_PATH
+      GST_OLD_GEM_HOME=$GEM_HOME
 
-        export GST_OLD_PATH GST_OLD_GEM_PATH GST_OLD_GEM_HOME
+      export GST_OLD_PATH GST_OLD_GEM_PATH GST_OLD_GEM_HOME
 
-        GS_NAME=$(pwd | sed -E "s/^.*\/(.*)$/\\1/")
-        PATH="$GS_DIR/bin":$PATH
-        GEM_PATH=$GS_DIR:$GEM_PATH
-        GEM_HOME=$GS_DIR
+      GS_NAME=$(pwd | sed -E "s/^.*\/(.*)$/\\1/")
+      PATH="$GS_DIR/bin":$PATH
+      GEM_PATH=$GS_DIR:$GEM_PATH
+      GEM_HOME=$GS_DIR
 
-        export PATH GEM_PATH GEM_HOME GS_NAME
-      fi
-
-      if [[ -n $2 ]]; then ${@:2}; fi
-    else
-      echo "Directory .gs not found. Run \`gst init\` first."
+      export PATH GEM_PATH GEM_HOME GS_NAME
     fi
+
+    if [[ -n $2 ]]; then ${@:2}; fi
     ;;
   "out")
     if [[ -n $GS_NAME ]]; then


### PR DESCRIPTION
So one thing Ruby does when you set a GEM_HOME that doesn't exist is run a `mkdir -p` before trying to fetch the dependencies:

``` shell
$ ls -a
.            ..           .gems        .git         CHANGELOG    CONTRIBUTING LICENSE      README.md    lib          makefile     syro.gemspec test

$ export GEM_HOME="$PWD"/.gs/even-more-nesting

$ gem install rack
$ tree -L 2 .gs
.gs
└── even-more-nesting
    ├── bin
    ├── build_info
    ├── cache
    ├── doc
    ├── extensions
    ├── gems
    └── specifications

8 directories, 0 files
```

This means we can just forget about checking for the existence of the directory, something that has inconvenienced me a million times. Do you think we could add this change?

Btw: you probably want to test this, I haven even ran the file because I'm a very bad github citizen, I promise to make it up to you with hugs and chocolate. :dancer:
